### PR TITLE
[fix] Typo on search plugin page

### DIFF
--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -15,7 +15,7 @@ This bundle brings extra easy-to-use features to the Strapi eco-system.
 
 <list :items="features"></list>
 
-[**Search plugin:**](./search/search-plugin) Index your Strapi managed content easy and effectively to a (third-party) [**Search provider**](./search/providers) and be able to instantly show results on search.
+[**Search plugin:**](./search/plugin) Index your Strapi managed content easy and effectively to a (third-party) [**Search provider**](./search/providers) and be able to instantly show results on search.
 
 <alert>
 

--- a/docs/content/en/search/plugin.md
+++ b/docs/content/en/search/plugin.md
@@ -6,7 +6,7 @@ category: 🔍 Search
 position: 10
 badge: 1.0.0-alpha.1
 features:
-  - Index your contet
+  - Index your content
   - Configure each index and the fields
   - Search provider system
 futureFeatures:


### PR DESCRIPTION
**What does it do?**

It fixes the typo mistake on the search plugin docs page. 