### PR TITLE
Feature/rebuild indexes

### DIFF
--- a/packages/search/strapi-plugin-search/server/services/lifecycle.js
+++ b/packages/search/strapi-plugin-search/server/services/lifecycle.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { omit, pick } = require('lodash/fp');
+const { sanitize } = require('../utils/sanitize');
 
 /**
  * Gets lifecycle service
@@ -23,21 +23,13 @@ module.exports = () => ({
         if (strapi.contentTypes[name]) {
           const indexName = indexPrefix + (index ? index : name);
 
-          const sanitize = (result) => {
-            if (fields.length > 0) {
-              return pick(fields, result);
-            }
-
-            return omit(excludedFields, result);
-          };
-
           strapi.db.lifecycles.subscribe({
             models: [name],
 
             async afterCreate(event) {
               provider.create({
                 indexName,
-                data: sanitize(event.result),
+                data: sanitize(event.result, fields, excludedFields),
                 id: idPrefix + event.result.id,
               });
             },
@@ -54,7 +46,7 @@ module.exports = () => ({
             async afterUpdate(event) {
               provider.update({
                 indexName,
-                data: sanitize(event.result),
+                data: sanitize(event.result, fields, excludedFields),
                 id: idPrefix + event.result.id,
               });
             },

--- a/packages/search/strapi-plugin-search/server/services/provider.js
+++ b/packages/search/strapi-plugin-search/server/services/provider.js
@@ -69,7 +69,7 @@ module.exports = () => ({
             })),
           });
         } else {
-          strapi.log.error(`Search plugin bootstrap failed: Search plugin could not load lifecycles on model '${name}' as it doesn't exist.`);
+          strapi.log.error(`Search plugin rebuild failed: Search plugin could not rebuild index for '${name}' as it doesn't exist.`);
         }
       }
     } catch (error) {

--- a/packages/search/strapi-plugin-search/server/services/provider.js
+++ b/packages/search/strapi-plugin-search/server/services/provider.js
@@ -2,6 +2,7 @@
 
 const { wrapMethodWithError } = require('../utils/error');
 const { validateProvider, PROVIDER_METHODS } = require('../utils/validate');
+const { sanitize } = require('../utils/sanitize');
 
 /**
  * Gets provider service
@@ -35,6 +36,44 @@ module.exports = () => ({
     } catch (error) {
       strapi.plugin('search').provider = null;
       throw new Error(`Search plugin could not load provider '${pluginConfig.provider}': ${error.message}`);
+    }
+  },
+
+  /**
+   * Clears and then re-populates search indexes by calling findMany on the content type
+   *
+   * @param {Array<string>} specificTypes - The type names to re-populate the indexes for; if null, re-populates all types; if empty, re-populates no types
+   */
+  async rebuild(specificTypes) {
+    strapi.log.info('Rebuilding search indexes...');
+    try {
+      const { excludedFields = [], prefix: indexPrefix = '', contentTypes } = strapi.config.get('plugin.search');
+      const pluginInstance = strapi.plugin('search').provider;
+      const rebuildTypes = contentTypes.filter((contentType) => !specificTypes || specificTypes.includes(contentType.name));
+      strapi.log.trace(
+        `Rebuilding search indexes for ${rebuildTypes?.length || 0} types [${(rebuildTypes || []).map((type) => type.name).join(', ')}]`,
+      );
+      for (const contentType of rebuildTypes) {
+        strapi.log.trace(`Rebuilding search index for ${contentType.name}`);
+        const { name, index, prefix: idPrefix = '', fields = [] } = contentType;
+        if (strapi.contentTypes[name]) {
+          const indexName = indexPrefix + (index ? index : name);
+          pluginInstance.clear(indexName);
+          const entities = await strapi.entityService.findMany(name, {}); // Potentially expensive, TODO: paginate
+          strapi.log.trace(`Rebuilding search index for ${entities.length} entities in ${contentType.name}`);
+          await strapi.plugin('search').provider.createMany({
+            indexName,
+            data: entities.map((x) => ({
+              data: sanitize(x, fields, excludedFields),
+              id: idPrefix + x.id,
+            })),
+          });
+        } else {
+          strapi.log.error(`Search plugin bootstrap failed: Search plugin could not load lifecycles on model '${name}' as it doesn't exist.`);
+        }
+      }
+    } catch (error) {
+      strapi.log.error(`Search plugin rebuild failed: ${error.message}`);
     }
   },
 });

--- a/packages/search/strapi-plugin-search/server/utils/sanitize.js
+++ b/packages/search/strapi-plugin-search/server/utils/sanitize.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { omit, pick } = require('lodash/fp');
+
+/**
+ * Sanitizes the data object by picking the specific fields or omit the specific excluded fields.
+ *
+ * @param {Object} entity - the entity to sanitize
+ * @param {Array<string>} fields - the fields to pick from the entity
+ * @param {Array<string>} excludedFields - the fields to omit from the entity
+ * @returns {Object} - sanitized result
+ */
+const sanitize = (entity, fields, excludedFields) => {
+  if (fields.length > 0) {
+    return pick(fields, entity);
+  }
+
+  return omit(excludedFields, entity);
+};
+
+module.exports = { sanitize };

--- a/packages/search/strapi-plugin-search/server/utils/validate.js
+++ b/packages/search/strapi-plugin-search/server/utils/validate.js
@@ -2,7 +2,7 @@
 
 const { yup } = require('@strapi/utils');
 
-const PROVIDER_METHODS = ['create', 'update', 'delete', 'createMany', 'updateMany', 'deleteMany'];
+const PROVIDER_METHODS = ['create', 'update', 'delete', 'createMany', 'updateMany', 'deleteMany', 'clear'];
 
 /**
  * Validates plugin configuration

--- a/packages/search/strapi-provider-search-algolia/lib/index.js
+++ b/packages/search/strapi-provider-search-algolia/lib/index.js
@@ -157,6 +157,23 @@ module.exports = {
             throw new Error(`Algolia provider: ${error.message}`);
           });
       },
+
+      /**
+       * Clears all entities from a index
+       *
+       * @param {object} params - Paramaters
+       * @param {string} params.indexName - Name of the index
+       * @returns {Promise<algoliasearch.ChunkedBatchResponse>} Promise with chunked task
+       */
+      clear({ indexName }) {
+        return client
+          .initIndex(indexName)
+          .clearObjects()
+          .then(() => debug && strapi.log.debug(`Algolia provider: Cleared all entries from index '${indexName}'.`))
+          .catch((error) => {
+            throw new Error(`Algolia provider: ${error.message}`);
+          });
+      },
     };
   },
 };

--- a/packages/search/strapi-provider-search-algolia/tests/algolia.test.unit.js
+++ b/packages/search/strapi-provider-search-algolia/tests/algolia.test.unit.js
@@ -15,6 +15,7 @@ describe('Algolia provider', function () {
         createMany: expect.any(Function),
         updateMany: expect.any(Function),
         deleteMany: expect.any(Function),
+        clear: expect.any(Function),
       }),
     );
 
@@ -26,6 +27,8 @@ describe('Algolia provider', function () {
     await strapi.plugin('search').provider.createMany({ indexName: 'category', data: categories });
     await strapi.plugin('search').provider.updateMany({ indexName: 'category', data: categories });
     await strapi.plugin('search').provider.deleteMany({ indexName: 'category', ids: categories.map((category) => category.id) });
+    await strapi.plugin('search').provider.createMany({ indexName: 'category', data: categories });
+    await strapi.plugin('search').provider.clear({ indexName: 'category' });
 
     // eslint-disable-next-line node/no-unsupported-features/es-builtins
     await Promise.allSettled([
@@ -35,6 +38,7 @@ describe('Algolia provider', function () {
       strapi.plugin('search').provider.createMany({ indexName: '', data: categories }),
       strapi.plugin('search').provider.updateMany({ indexName: '', data: categories }),
       strapi.plugin('search').provider.deleteMany({ indexName: '', ids: categories.map((category) => category.id) }),
+      strapi.plugin('search').provider.clear({ indexName: '' }),
     ]).then((results) => results.forEach((result) => expect(result.value).toBeUndefined()));
   });
 


### PR DESCRIPTION
We have issues where on a deployment we want to force a complete re-indexing. This PR enables this by:
- Adding a `clear()` method to the provider interface (and implementing it for Algolia)
- Adding a `rebuild()` method to the service to enable programmatic reindexing

The `rebuild()` method comes with the caveat that it includes a `findMany()` call that retrieves all entities; for large tables this may be expensive.

I have not implemented an admin interface but this would be an obvious next step.