### PR TITLE
[Plugin] populate support

### DIFF
--- a/packages/search/strapi-plugin-search/server/services/lifecycle.js
+++ b/packages/search/strapi-plugin-search/server/services/lifecycle.js
@@ -18,13 +18,13 @@ module.exports = () => ({
     // Loop over configured contentTypes in ./config/plugins.js
     contentTypes &&
       contentTypes.forEach((contentType) => {
-        const { name, index, prefix: idPrefix = '', fields = [], populate = [] } = contentType;
+        const { name, index, prefix: idPrefix = '', fields = [], populate = null } = contentType;
 
         if (strapi.contentTypes[name]) {
           const indexName = indexPrefix + (index ? index : name);
 
           const sanitize = async (result) => {
-            if (populate.length) {
+            if (populate) {
               result = await strapi.entityService.findOne(name, result.id, {
                 populate
               })


### PR DESCRIPTION
It will allow to populate relations before sending it to provider.
Example usage:
```
contentTypes: [
    { name: 'api::post.post', populate: ['tags'] }
],
```
https://github.com/MattieBelt/mattie-strapi-bundle/issues/139